### PR TITLE
Fix Modified Date Bug

### DIFF
--- a/converters/bbx2cpwpw.py
+++ b/converters/bbx2cpwpw.py
@@ -157,7 +157,7 @@ for name in tqdm(image_list):
     except KeyError:
         # en: default to date modified in case 36867 (date taken) is unavailable
         #   some makes/firmware versions don't include 36867 in the exif
-        timestamp = os.path.getmtime(file_name)
+        timestamp = datetime.datetime.fromtimestamp(os.path.getmtime(file_name))
     cur.execute(
         '''INSERT INTO Photos (ImageNum, FileName, ImageDate, FilePath, VisitID, Pending, ObsCount)
         VALUES (?, ?, ?, ?, ?, True, 1 )''', (counter, name, timestamp, IMAGE_PATH, VISITID))

--- a/database-tools/cpwpw.py
+++ b/database-tools/cpwpw.py
@@ -197,7 +197,7 @@ for name in tqdm(image_list):
     except KeyError:
         # en: default to date modified in case 36867 (date taken) is unavailable
         #   some makes/firmware versions don't include 36867 in the exif
-        timestamp = os.path.getmtime(file_name)
+        timestamp = datetime.datetime.fromtimestamp(os.path.getmtime(file_name))
     # en: added Pending and ObsCount flags
     cur.execute(
         '''INSERT INTO Photos (ImageNum, FileName, ImageDate, FilePath, VisitID, Pending, ObsCount)


### PR DESCRIPTION
Previous version attempted to pass the date as a float when falling back to date modified, which caused an ODBC error when inserting on the Photos table.