### PR TITLE
Update bbx2cpwpw.py

### DIFF
--- a/converters/bbx2cpwpw.py
+++ b/converters/bbx2cpwpw.py
@@ -184,20 +184,24 @@ for name in tqdm(image_list):
             YLen = (bbox['ymax'] - bbox['ymin'])
             TagX = bbox['xmin'] + (XLen / 2.0)
             TagY = bbox['ymin'] + (YLen / 2.0)
+            # en: Moving the species lookup up a few lines avoids issues when
+            #   there are duplicate labels in the .bbx file, e.g. 'red deer' vs.
+            #   'Red Deer'
+            SPECIES_ID = SPECIES[a['label'].lower()]
             for obs in OBSID.keys():
                 cur.execute(
                     '''INSERT INTO PhotoTags (TagX, TagY, XLen, YLen, ImageID, ObsID)
                     VALUES (?, ?, ?, ?, ?, ?)''', (TagX, TagY, XLen, YLen, image_rec_id, OBSID[obs]))
-            if a['label'] not in detections:
-                detections[a['label']] = 1.0
+            if SPECIES_ID not in detections:
+                detections[SPECIES_ID] = 1.0
             else:
-                detections[a['label']] += 1.0
+                detections[SPECIES_ID] += 1.0
 
         for d in detections.keys():
             for obs in OBSID.keys():
                 cur.execute(
                     '''INSERT INTO Detections (SpeciesID, Individuals, ObsID, ImageID, StatusID)
-                    VALUES (?, ?, ?, ?, ?)''', (SPECIES[d.lower()], detections[d], OBSID[obs], image_rec_id, STATUS_ID))
+                    VALUES (?, ?, ?, ?, ?)''', (d, detections[d], OBSID[obs], image_rec_id, STATUS_ID))
     else:
         for obs in OBSID.keys():
             cur.execute(


### PR DESCRIPTION
Avoid a bug with duplicate labels

I ran into a .bbx file with labels for both 'Red Deer' and 'red deer' for the same photo. Those weren't getting combined correctly in the `detections` dictionary before import.

```json
        "img_838.jpg": {
            "attribution": "anon",
            "license": "N/A",
            "license_url": "N/A",
            "annotations": [
                {
                    "created_by": "machine",
                    "updated_by": "",
                    "bbox": {
                        "xmin": 0.0,
                        "xmax": 0.28004181385040283,
                        "ymin": 0.37151461839675903,
                        "ymax": 0.6296362280845642
                    },
                    "label": "red deer",
                    "occluded": "N",
                    "truncated": "N",
                    "difficult": "N",
                    "schema": "1.0.0"
                },
                {
                    "created_by": "human",
                    "updated_by": "human",
                    "bbox": {
                        "xmin": 0.9380430643160045,
                        "xmax": 1.0,
                        "ymin": 0.0692172364396041,
                        "ymax": 0.3074950923275191
                    },
                    "label": "Red Deer",
                    "occluded": "N",
                    "truncated": "N",
                    "difficult": "N",
                    "schema": "1.0.0"
                }
            ]
        }
```